### PR TITLE
EES-6532 Use latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ansible-oauth2-proxy
-An ansible role to install [oauth2 proxy](https://github.com/bitly/oauth2_proxy) 
+An ansible role to install [oauth2 proxy](https://github.com/bitly/oauth2_proxy)
 
 Variables
 ---------
 
 ```yaml
-oaut2_proxy_http                         : "https://github.com/bitly/oauth2_proxy/releases/download/v2.0.1/oauth2_proxy-2.0.1.linux-amd64.go1.4.2.tar.gz"
-oaut2_proxy_http_sha256                  : "c6d8f6d74e1958ce1688f3cf7d60648b9d0d6d4344d74c740c515a00b4e023ad"
+oaut2_proxy_http                         : "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v7.1.3/oauth2-proxy-v7.1.3.linux-amd64.tar.gz"
+oaut2_proxy_http_sha256                  : "a491ca18059848c356935fe2ca9e665faafe4bba3ee1ecbac5a5f5f193195a82"
 oauth2_user                              : "oauth2"
 oauth2_dir                               : "/var/oauth2_proxy"
 oauth2_dir_tmp                           : "/var/oauth2_proxy/tmp"
@@ -19,7 +19,7 @@ oauth2_filename                          : "{{ oauth2_compress_filename |replace
 oauth2_proxy_config                      :
     http_address                         : "127.0.0.1:5000"
     upstreams                            : [ "127.0.0.1:6060" ]
-    provider                             : "github" 
+    provider                             : "github"
     email-domain                         : "*"
     cookie-secure                        : false
     cookie-domain                        : "localhost:5000"
@@ -27,7 +27,7 @@ oauth2_proxy_config                      :
     client_id                            : "YOUR_CLIENT_ID"
     client_secret                        : "CLIENT_SECERET"
 
-oauth2_config_cmdline_args               : "-github-org='MYCoolORg'"
+oauth2_config_cmdline_args               : "--github-org='MYCoolORg'"
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-oaut2_proxy_http                         : "https://github.com/bitly/oauth2_proxy/releases/download/v2.0.1/oauth2_proxy-2.0.1.linux-amd64.go1.4.2.tar.gz"
-oaut2_proxy_http_sha256                  : "c6d8f6d74e1958ce1688f3cf7d60648b9d0d6d4344d74c740c515a00b4e023ad"
+oaut2_proxy_http                         : "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v7.1.3/oauth2-proxy-v7.1.3.linux-amd64.tar.gz"
+oaut2_proxy_http_sha256                  : "a491ca18059848c356935fe2ca9e665faafe4bba3ee1ecbac5a5f5f193195a82"
 oauth2_user                              : "oauth2"
 oauth2_dir                               : "/var/oauth2_proxy"
 oauth2_dir_tmp                           : "/var/oauth2_proxy/tmp"
@@ -14,7 +14,7 @@ oauth2_filename                          : "{{ oauth2_compress_filename |replace
 oauth2_proxy_config                      :
     http_address                         : "127.0.0.1:5000"
     upstreams                            : [ "127.0.0.1:6060" ]
-    provider                             : "github" 
+    provider                             : "github"
     email-domain                         : "*"
     cookie-secure                        : false
     cookie-domain                        : "localhost:5000"
@@ -22,4 +22,4 @@ oauth2_proxy_config                      :
     client_id                            : "YOUR_CLIENT_ID"
     client_secret                        : "CLIENT_SECERET"
 
-oauth2_config_cmdline_args               : "-github-org='MYCoolORg'"
+oauth2_config_cmdline_args               : "--github-org='MYCoolORg'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: Create the directories for site specific configurations
-  user: 
+  user:
     name="{{ oauth2_user }}"
     shell="/bin/false"
     home="{{ oauth2_dir }}"
 
 - name: Create the directories for site specific configurations
-  file: 
+  file:
     path="{{ item }}"
     state=directory
     owner="{{ oauth2_user }}"
@@ -26,37 +26,44 @@
     owner="{{ oauth2_user }}"
 
 - name: unarchive oauth2 binary
-  unarchive: 
+  unarchive:
     src="{{ oauth2_dir_tmp }}/{{ oauth2_compress_filename }}"
     dest="{{ oauth2_dir }}/"
     creates="{{ oauth2_dir }}/{{ oauth2_compress_filename }}"
     copy=no
 
 - name: Create current symlink
-  file: 
+  file:
     src="{{ oauth2_dir }}/{{ oauth2_filename }}"
     dest="{{ oauth2_dir }}/current"
     owner="{{ oauth2_user }}"
     mode="0755"
     state="link"
-  notify: 
+  notify:
     - oauth2-proxy restart
 
 - name: Deploy init.d script
-  template: 
+  template:
     src="init.d.sh.j2.sh"
     dest="/etc/init.d/oauth2-proxy"
     mode="0755"
-  notify: 
+  register: initd_script
+  notify:
     - oauth2-proxy restart
 
+- name: Reload Systemd
+  systemd:
+    daemon_reload=yes
+    name=oauth2-proxy
+  when: initd_script.changed and ansible_service_mgr == 'systemd'
+
 - name: Deploy Config
-  template: 
+  template:
     src="config.j2"
     dest="{{ oauth2_config_path }}"
     owner="{{ oauth2_user }}"
     mode="0600"
-  notify: 
+  notify:
     - oauth2-proxy restart
 
 - name: Service start

--- a/templates/init.d.sh.j2.sh
+++ b/templates/init.d.sh.j2.sh
@@ -17,8 +17,8 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="A reverse proxy that provides authentication with Google, Github or other provider"
 NAME=`basename $0`
-DAEMON={{ oauth2_dir }}/current/oauth2_proxy
-DAEMON_ARGS="-config={{ oauth2_config_path }} {{ oauth2_config_cmdline_args }}"
+DAEMON={{ oauth2_dir }}/current/oauth2-proxy
+DAEMON_ARGS="--config={{ oauth2_config_path }} {{ oauth2_config_cmdline_args }}"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/oauth2-proxy
 USER={{ oauth2_user }}


### PR DESCRIPTION
Use the latest version of oauth-proxy.

The current version no longer works with Github as some features it uses has [been deprecated](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/#removal-date).